### PR TITLE
fix: adding movement offset to prevent position set to center

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -44,9 +44,12 @@ export function Card(props: CardProps) {
       return
     }
 
+    const rect = event.target.getBoundingClientRect()
+
     setCards((card) => card.id === props.card.id, {
-      positionY: event.clientY,
-      positionX: event.clientX,
+      positionY:
+        event.pageY + rect.height / 2 - event.offsetY + event.movementY,
+      positionX: event.pageX + rect.width / 2 - event.offsetX + event.movementX,
     })
   }
 


### PR DESCRIPTION
Adding offset to prevent card position reseting to mouse position on start drag movement