### PR TITLE
fix: card menu click

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -92,6 +92,10 @@ export function Card(props: CardProps) {
   }
 
   function handleMouseDown(event: MouseEvent) {
+    const rect = cardElementRef.getBoundingClientRect()
+
+    if (event.clientY < rect.y) return
+
     setMouseDownPos({ y: event.offsetY, x: event.offsetX })
     setIsDragging(true)
   }


### PR DESCRIPTION
This PR fix a bug that made it impossible delete a card.
When trying to delete a card, a dragging is triggered. 